### PR TITLE
Cleanup lakefile.lean & remove `lean_lib`

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,14 +1,7 @@
 import Lake
 open Lake DSL
 
-package «ntptutorial» {
-  -- add any package configuration options here
-}
+package «ntptutorial»
 
 require mathlib from git
   "https://github.com/leanprover-community/mathlib4.git"
-
-@[default_target]
-lean_lib «Ntptutorial» {
-  -- add any library configuration options here
-}


### PR DESCRIPTION
The repository lakefile currently has a `@[default_target] lean_lib «Ntptutorial»`, which tells Lake that a default build of the project should attempt to find a build a file call `Ntptutorial.lean`. As such a file does not exist, this fails and results in package indexing tools like [Reservoir](https://reservoir.lean-lang.org/) marking the package with a build failure.

This PR removes this unnecessary `lean_lib`, fixing this build issue, and also cleans up the `package` command in the lakefile.